### PR TITLE
Fix implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ def surftmex(x, dim=-1):
   maxes = torch.max(x, dim, keepdim=True)[0]
   x_exp = torch.exp(x-maxes)
   x_exp_sum = torch.sum(x_exp, dim, keepdim=True)
-  output_custom = x_exp/(1+x_exp_sum) # << The key bit is the +1
+  output_custom = x_exp/(torch.exp(-maxes)+x_exp_sum) # << The key bit is the +torch.exp(-maxes)
   return output_custom
 
 # And then in the attention implementation we do:

--- a/model.py
+++ b/model.py
@@ -20,7 +20,7 @@ def surftmex(x, dim=-1):
   maxes = torch.max(x, dim, keepdim=True)[0]
   x_exp = torch.exp(x-maxes)
   x_exp_sum = torch.sum(x_exp, dim, keepdim=True)
-  output_custom = x_exp/(1+x_exp_sum) # << The key bit is the +1
+  output_custom = x_exp/(torch.exp(-maxes)+x_exp_sum) # << The key bit is the +torch.exp(-maxes)
   return output_custom
 
 class LayerNorm(nn.Module):


### PR DESCRIPTION
I think your custom "surftmex" function (with the + 1 in the denominator) is slightly incorrect. After performing the "subtract by maximum to ensure numerical stability" trick, you must divide by `torch.exp(-maxes) + x_exp_sum` instead of `1 + x_exp_sum`. 
![image](https://github.com/johnowhitaker/nanoGPT_QuietAttention/assets/26504141/89aa17be-be5a-4b76-89e1-8273b13da216)


For comparison, I implemented the unstable surftmex function directly by its definition (just to test correctness for small values).
![image](https://github.com/johnowhitaker/nanoGPT_QuietAttention/assets/26504141/310576f1-f93d-4725-95e5-3f7a78f026aa)


As shown below, the fixed version produces the same result as the unstable version.
![image](https://github.com/johnowhitaker/nanoGPT_QuietAttention/assets/26504141/1c2958d4-3a2d-4dff-80df-d2b46caf312c)


I made a tweet about it here: https://twitter.com/xenovacom/status/1683595584186249217